### PR TITLE
ETCD backup

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -31,11 +31,13 @@ ${join("\n", data.template_file.etcd-member.*.rendered)}
     name: main
     enableEtcdTLS: ${var.etcd-enable-tls}
     version: ${var.etcd-version}
+${data.template_file.backup-main.rendered}
   - etcdMembers:
 ${join("\n", data.template_file.etcd-member.*.rendered)}
     name: events
     enableEtcdTLS: ${var.etcd-enable-tls}
     version: ${var.etcd-version}
+${data.template_file.backup-events.rendered}
 EOF
 
     # Kubelet configuration
@@ -82,6 +84,24 @@ EOF
   vars {
     az = "${element(var.master-availability-zones, count.index)}"
   }
+}
+
+data "template_file" "backup-main" {
+  count = "${var.etcd-backup-enabled ? 1 : 0}"
+
+  template = <<EOF
+    backups:
+      backupStore: s3://${var.kops-state-bucket}/backups/${var.cluster-name}/etcd/main/
+EOF
+}
+
+data "template_file" "backup-events" {
+  count = "${var.etcd-backup-enabled ? 1 : 0}"
+
+  template = <<EOF
+    backups:
+      backupStore: s3://${var.kops-state-bucket}/backups/${var.cluster-name}/etcd/events/
+EOF
 }
 
 data "template_file" "trusted-cidrs" {

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -109,6 +109,13 @@ variable "etcd-enable-tls" {
   default = "true"
 }
 
+variable "etcd-backup-enabled" {
+  type        = "string"
+  description = "Set to true to enable backup to S3 on etcd containers (default: true)"
+
+  default = "false"
+}
+
 variable "container-networking" {
   type        = "string"
   description = "Set the container CNI networking layer (https://github.com/kubernetes/kops/blob/master/docs/networking.md)"


### PR DESCRIPTION
The feature of backups is broken as of now (with kops 1.9.x) but should be usable with kops 1.10