### PR TITLE
Decrease TTL of NXDOMAIN responses for cluster domain

### DIFF
--- a/aws/cluster/route53.tf
+++ b/aws/cluster/route53.tf
@@ -2,6 +2,15 @@
  * Cluster public subdomain configuration
  */
 
+locals {
+  dns_soa_hostmaster   = "awsdns-hostmaster.amazon.com"
+  dns_soa_refresh_time = 7200
+  dns_soa_retry_time   = 900
+  dns_soa_expire_time  = 1209600
+  dns_soa_negative_ttl = 60
+  dns_soa_appendix     = "${local.dns_soa_hostmaster}. 1 ${local.dns_soa_refresh_time} ${local.dns_soa_retry_time} ${local.dns_soa_expire_time} ${local.dns_soa_negative_ttl}"
+}
+
 resource "aws_route53_zone" "cluster" {
   name          = "${var.cluster-name}"
   force_destroy = true
@@ -21,4 +30,14 @@ resource "aws_route53_record" "cluster-root" {
     "${aws_route53_zone.cluster.name_servers.2}",
     "${aws_route53_zone.cluster.name_servers.3}",
   ]
+}
+
+resource "aws_route53_record" "cluster-soa" {
+  zone_id = "${aws_route53_zone.cluster.id}"
+  name    = "${aws_route53_zone.cluster.name}"
+  type    = "SOA"
+  ttl     = "60"
+  records = ["${aws_route53_zone.cluster.name_servers.0}. ${local.dns_soa_appendix}"]
+
+  allow_overwrite = true
 }


### PR DESCRIPTION
The AWS default for negative caching is 86400, which is not very service-discovery-friendly, should the client really cache the NXDOMAIN for that long. This PR lowers TTL to 60 seconds.